### PR TITLE
Handle keyword-only args and annotations on Python 3.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@
 
 - Docstrings are treated as UTF-8 on Python 2.
 
+- Handle keyword only arguments and annotations in function signatures
+  on Python 3.
+
 3.7.5 (2010-09-12)
 ==================
 

--- a/src/zope/app/apidoc/static.py
+++ b/src/zope/app/apidoc/static.py
@@ -185,6 +185,7 @@ class PublisherBrowser(zope.testbrowser.wsgi.Browser):
     def setDebugMode(self, debug):
         self.handleErrors = not debug
 
+
 class ArbitraryLink(zope.testbrowser.browser.Link):
 
     attr_name = 'src'


### PR DESCRIPTION
Just use ``str(inspect.signature(func))``, which is much simpler and handles everything. The only work we need to do is strip out `(self)` when requested.

Fixes #5