### PR TITLE
Display Class Finder entries on separate lines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@
   establish a working Zope 3 publication environment. The easiest way to do so is to include this line in the ZCML:
   ``<include package='zope.app.apidoc' file='static.zcml' condition='have static-apidoc' />``. 
   See `PR #13 <https://github.com/zopefoundation/zope.app.apidoc/pull/13/>`_.
+- Class Finder entries in live apidoc are now displayed on separate lines, like in static exports. 
+  See `PR #14 <https://github.com/zopefoundation/zope.app.apidoc/pull/14/>`_.
 
 4.0.0 (2017-05-25)
 ==================

--- a/src/zope/app/apidoc/codemodule/browser/menu.pt
+++ b/src/zope/app/apidoc/codemodule/browser/menu.pt
@@ -22,13 +22,14 @@
 
     <div tal:define="classes view/findClasses"
          tal:condition="classes">
-
-      <a href="" target="main"
-         tal:repeat="info classes"
-         tal:attributes="href info/url"
-         tal:content="info/path">
-        /zope/app/Application
-      </a>
+      <tal:omit-tag tal:repeat="info classes">
+        <a href="" target="main"
+          tal:attributes="href info/url"
+          tal:content="info/path">
+          /zope/app/Application
+        </a>
+        <br />
+      </tal:omit-tag>
     </div>
 
   </div>


### PR DESCRIPTION
Cosmetic fix; `static-menu.pt` already does this, but the change was never carried
over to `menu.pt`