### PR TITLE
 Fix static Class Finder search form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@
   See `PR #13 <https://github.com/zopefoundation/zope.app.apidoc/pull/13/>`_.
 - Class Finder entries in live apidoc are now displayed on separate lines, like in static exports. 
   See `PR #14 <https://github.com/zopefoundation/zope.app.apidoc/pull/14/>`_.
+- Class Finder search in static exports will search on Enter, not just when clicking "Find". 
+  See `PR #15 <https://github.com/zopefoundation/zope.app.apidoc/pull/15/>`_.
 
 4.0.0 (2017-05-25)
 ==================

--- a/src/zope/app/apidoc/codemodule/browser/static_menu.pt
+++ b/src/zope/app/apidoc/codemodule/browser/static_menu.pt
@@ -5,7 +5,7 @@
   <div metal:fill-slot="menu" class="small">
 
     <div>
-      <span i18n:translate="">Class Finder:</span><br />
+      <span i18n:translate="">Class Finder:</span>
       <span><i i18n:translate="">(Enter partial Python path)</i></span>
 	</div>
     <form action="" method="post" name="searchform"

--- a/src/zope/app/apidoc/codemodule/browser/static_menu.pt
+++ b/src/zope/app/apidoc/codemodule/browser/static_menu.pt
@@ -5,19 +5,18 @@
   <div metal:fill-slot="menu" class="small">
 
     <div>
-      <span i18n:translate="">Class Finder:</span>
+      <span i18n:translate="">Class Finder:</span><br />
       <span><i i18n:translate="">(Enter partial Python path)</i></span>
 	</div>
-    <form action="#" method="post" name="searchform" >
-	  <br />
+    <form action="" method="post" name="searchform"
+          onsubmit="simplegetSearchResult(document.searchform.path.value);
+                    return false">
       <input type="text" name="path"
-             style="font-size: 80%; width=95%" />
+             style="font-size: 80%; width: 95%" />
 
 	  <br />
-      <input type="button" name="Find" value="Find"
-	     onClick="
-               javascript:simplegetSearchResult(document.searchform.path.value)"
-             i18n:attributes="value find-button" style="font-size: 80%"/>
+      <input type="submit" name="Find" value="Find"
+             i18n:attributes="value find-button" style="font-size: 80%" />
 
 <!--
       <input type="submit" name="SUBMIT" value="Find"


### PR DESCRIPTION
Moving the **Find** button action to the form element makes it so hitting return in the search bar will search instead of refreshing the frame. This matches the search behavior that `menu.pt` exhibits, and is probably expected behavior in general.

Additionally, fix a typo in the form styling.