### PR TITLE
Fix codemodule.Module when the module has a __file__ of None.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 language: python
 sudo: false
-python:
-  - 2.7
-  - 3.4
-  - 3.5
-  - 3.6
-  - pypy-5.4.1
+group: travis_latest
+language: python
+jobs:
+    include:
+      - python: 2.7
+      - python: 3.4
+      - python: 3.5
+      - python: 3.6
+      - python: 3.7
+        dist: xenial
+        sudo: true
+      - python: pypy
+      - python: pypy3
 script:
 # Coverage slows this old pypy down to several minutes
   - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then zope-testrunner --test-path=src; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ jobs:
         dist: xenial
         sudo: true
       - python: pypy
-      - python: pypy3
 script:
 # Coverage slows this old pypy down to several minutes
   - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then zope-testrunner --test-path=src; fi

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,13 +5,21 @@
 4.0.1 (unreleased)
 ==================
 
+- Add support for Python 3.7.
+
+- Fix ``codemodule.Module`` for modules that have a ``__file__`` of
+  ``None``. This can be the case with namespace packages, especially
+  under Python 3.7. See `issue #17 <https://github.com/zopefoundation/zope.app.apidoc/issues/17>`_.
+
 - Host documentation at https://zopeappapidoc.readthedocs.io/
 
-- Add argument to ``static-apidoc`` for loading a specific ZCML file. To use this feature, the ZCML file you specify needs to 
+- Add argument to ``static-apidoc`` for loading a specific ZCML file. To use this feature, the ZCML file you specify needs to
   establish a working Zope 3 publication environment. The easiest way to do so is to include this line in the ZCML:
-  ``<include package='zope.app.apidoc' file='static.zcml' condition='have static-apidoc' />``. 
-  See `PR #13 <https://github.com/zopefoundation/zope.app.apidoc/pull/13/>`_.
-- Class Finder entries in live apidoc are now displayed on separate lines, like in static exports. 
+  ``<include package='zope.app.apidoc' file='static.zcml' condition='have static-apidoc' />``.
+  See `PR #13
+  <https://github.com/zopefoundation/zope.app.apidoc/pull/13/>`_.
+
+- Class Finder entries in live apidoc are now displayed on separate lines, like in static exports.
   See `PR #14 <https://github.com/zopefoundation/zope.app.apidoc/pull/14/>`_.
 
 4.0.0 (2017-05-25)

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Natural Language :: English',

--- a/src/zope/app/apidoc/codemodule/module.py
+++ b/src/zope/app/apidoc/codemodule/module.py
@@ -72,7 +72,9 @@ class Module(ReadContainerBase):
 
     def __setup_package(self):
         # Detect packages
-        module_file = getattr(self._module, '__file__', '')
+        # __file__ can be None, especially with namespace packages on
+        # Python 3.7
+        module_file = getattr(self._module, '__file__', None) or ''
         module_path = getattr(self._module, '__path__', None)
         if module_file.endswith(('__init__.py', '__init__.pyc', '__init__.pyo')):
             self._package = True

--- a/src/zope/app/apidoc/codemodule/tests.py
+++ b/src/zope/app/apidoc/codemodule/tests.py
@@ -107,6 +107,18 @@ class TestModule(unittest.TestCase):
         self.assertEqual(mod['app']._module, zope.app)
         self.assertEqual(mod['app']['apidoc']._module, zope.app.apidoc)
 
+    def test_module_with_file_of_none(self):
+        # Sometimes namespace packages have this,
+        # especially on Python 3.7.
+        class Mod(object):
+            __file__ = None
+            __name__ = 'name'
+        Mod.__doc__ = "A module"
+
+        mod = Module(None, 'name', Mod())
+        self.assertEqual(Mod.__doc__, mod.getDocString())
+
+
 class TestZCML(unittest.TestCase):
 
     def setUp(self):

--- a/src/zope/app/apidoc/codemodule/tests.py
+++ b/src/zope/app/apidoc/codemodule/tests.py
@@ -113,10 +113,12 @@ class TestModule(unittest.TestCase):
         class Mod(object):
             __file__ = None
             __name__ = 'name'
-        Mod.__doc__ = "A module"
 
-        mod = Module(None, 'name', Mod())
-        self.assertEqual(Mod.__doc__, mod.getDocString())
+        mod = Mod()
+        mod.__doc__ = 'A module'
+
+        inst = Module(None, 'name', mod)
+        self.assertEqual(mod.__doc__, inst.getDocString())
 
 
 class TestZCML(unittest.TestCase):

--- a/src/zope/app/apidoc/tests.py
+++ b/src/zope/app/apidoc/tests.py
@@ -167,7 +167,7 @@ class TestPresentation(unittest.TestCase):
 
 class TestUtilities(unittest.TestCase):
 
-    # All three implementations (Py2, PyPy2, Python 3) do different
+    # All four implementations (Py2, PyPy2, Python 3, PyPy3) do different
     # things with slot method descriptors
     @unittest.skipIf(str is not bytes or hasattr(sys, 'pypy_version_info'),
                      "Only on CPython2")
@@ -175,7 +175,8 @@ class TestUtilities(unittest.TestCase):
         from zope.app.apidoc.utilities import getFunctionSignature
         self.assertEqual("(<unknown>)", getFunctionSignature(object.__init__))
 
-    @unittest.skipIf(str is bytes, "Only on CPython3")
+    @unittest.skipIf(str is bytes or hasattr(sys, 'pypy_version_info'),
+                     "Only on CPython3")
     def test_slot_methods3(self):
         from zope.app.apidoc.utilities import getFunctionSignature
         self.assertEqual(
@@ -183,7 +184,7 @@ class TestUtilities(unittest.TestCase):
             getFunctionSignature(object.__init__))
 
     @unittest.skipIf(str is not bytes or not hasattr(sys, 'pypy_version_info'),
-                     "Only on PyPy")
+                     "Only on PyPy2")
     def test_slot_methodspypy2(self): # pragma: no cover (we don't run coverage on pypy)
         from zope.app.apidoc.utilities import getFunctionSignature
         self.assertEqual("(obj, *args, **keywords)", getFunctionSignature(object.__init__))
@@ -262,10 +263,10 @@ class TestStatic(unittest.TestCase):
                              tmpdir])
         self.assertEqual(9, maker.counter) # our six default images, plus scripts
         self.assertEqual(1, maker.linkErrors)
-    
+
     def test_custom_zcml(self):
         # This test uses the ZCML directive list to determine if a custom ZCML file was successfully loaded
-        
+
         tmpdir = self._tempdir()
         directive = 'fakeModuleImport'
         package_name = 'zope.app.apidoc'
@@ -275,7 +276,7 @@ class TestStatic(unittest.TestCase):
         static.main(['--max-runtime', '10', os.path.join(tmpdir, 'default')])
         with open(os.path.join(tmpdir, 'default', '++apidoc++/ZCML/@@staticmenu.html')) as document:
             self.assertNotIn(directive, document.read())
-        
+
         # Make sure that the directive is listed when we specify our custom ZCML file
         static.main(['--max-runtime', '10', os.path.join(tmpdir, 'custom'), '-c', '%s:%s' % (package_name, zcml_file)])
         with open(os.path.join(tmpdir, 'custom', '++apidoc++/ZCML/@@staticmenu.html')) as document:
@@ -347,13 +348,13 @@ class TestStatic(unittest.TestCase):
 
         with self.assertRaises(SystemExit):
             static._create_arg_parser().parse_args([tmpdir, '--publisher', '---custom-publisher', 'fake'])
-        
+
         with self.assertRaises(SystemExit):
             static._create_arg_parser().parse_args([tmpdir, '-publisher', '--webserver'])
-        
+
         with self.assertRaises(SystemExit):
             static._create_arg_parser().parse_args([tmpdir, '--webserver', '--custom-publisher', 'fake'])
-        
+
 
 # Generally useful classes and functions
 

--- a/src/zope/app/apidoc/utilities.rst
+++ b/src/zope/app/apidoc/utilities.rst
@@ -461,7 +461,7 @@ However, lists of this type are not allowed inside the argument list::
   ...     pass
   Traceback (most recent call last):
   ...
-  SyntaxError: invalid syntax
+  SyntaxError: invalid syntax...
 
 Internal assignment is also not legal::
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,pypy
+envlist = py27,py34,py35,py36,py37,pypy
 
 [testenv]
 commands =


### PR DESCRIPTION
Fixes #17

Also add Python 3.7 support, since this unblocks that.