### PR TITLE
Make handling of root Code modules more consistent.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,15 @@
 
 - Add support for Python 3.7.
 
+- The root ``Code`` documentation node no longer allows incidental
+  traversal and documentation of unregistered root modules such as
+  ``re`` and ``logging`` (``builtins`` is special cased). These were
+  not listed in the tables of contents or menus, and mostly served to
+  slow down static exports. To document a root module, explicitly
+  include it in ZCML with ``<apidoc:rootModule module="MODULE" />``.
+  See `issue #20
+  <https://github.com/zopefoundation/zope.app.apidoc/issues/20>`_.
+
 - Fix ``codemodule.Module`` for modules that have a ``__file__`` of
   ``None``. This can be the case with namespace packages, especially
   under Python 3.7. See `issue #17 <https://github.com/zopefoundation/zope.app.apidoc/issues/17>`_.

--- a/src/zope/app/apidoc/codemodule/README.rst
+++ b/src/zope/app/apidoc/codemodule/README.rst
@@ -30,7 +30,7 @@ obviously a bit different:
   True
 
   >>> sorted(cm.keys())
-  [u'BTrees', u'ZConfig', u'ZODB', u'persistent', u'transaction', ...]
+  [u'BTrees', u'ZConfig', u'ZODB', u'builtins', u'persistent', u'transaction', ...]
 
 
 Module

--- a/src/zope/app/apidoc/codemodule/browser/class_.py
+++ b/src/zope/app/apidoc/codemodule/browser/class_.py
@@ -83,6 +83,9 @@ class ClassDetails(object):
             except TraversalError:
                 # If one of the classes is implemented in C, we will not
                 # be able to find it.
+                # Likewise, if we are attempting to get a root module that
+                # was not a registered root, the CodeModule will not be able to
+                # find it either.
                 pass
             info.append({'path': path or None, 'url': url})
         return info

--- a/src/zope/app/apidoc/codemodule/codemodule.py
+++ b/src/zope/app/apidoc/codemodule/codemodule.py
@@ -75,6 +75,15 @@ class CodeModule(Module):
             if module is not None:
                 self._children[name] = Module(self, name, module)
 
+        # And the builtins are always available, since that's the
+        # most common root module linked to from docs.
+        builtin_module = safe_import('__builtin__') or safe_import('builtins')
+        assert builtin_module is not None
+        builtin_module = Module(self, builtin_module.__name__, builtin_module)
+        # Register with both names for consistency in the tests between Py2 and Py3
+        self._children['builtins'] = self._children['__builtin__'] = builtin_module
+
+
     def withParentAndName(self, parent, name):
         located = type(self)()
         located.__parent__ = parent
@@ -99,9 +108,6 @@ class CodeModule(Module):
 
     def get(self, key, default=None):
         self.setup()
-        # TODO: Do we really like that this allows importing things from
-        # outside our defined namespace? This can lead to a static
-        # export with unreachable objects (not in the menu)
         return super(CodeModule, self).get(key, default)
 
     def items(self):

--- a/src/zope/app/apidoc/codemodule/tests.py
+++ b/src/zope/app/apidoc/codemodule/tests.py
@@ -121,6 +121,23 @@ class TestModule(unittest.TestCase):
         self.assertEqual(mod.__doc__, inst.getDocString())
 
 
+class TestCodeModule(unittest.TestCase):
+
+    def test_find_builtins(self):
+        # CodeModule can always find builtins
+        # root modules.
+        import zope.app.apidoc.codemodule.codemodule
+        cm = zope.app.apidoc.codemodule.codemodule.CodeModule()
+        self.assertIsNotNone(cm.get('builtins'))
+
+    def test_not_find_logging(self):
+        # CodeModule other unregistered root modules,
+        # like logging, are not implicitly found.
+        import zope.app.apidoc.codemodule.codemodule
+        cm = zope.app.apidoc.codemodule.codemodule.CodeModule()
+        self.assertIsNone(cm.get('logging'))
+
+
 class TestZCML(unittest.TestCase):
 
     def setUp(self):

--- a/src/zope/app/apidoc/ifacemodule/browser.py
+++ b/src/zope/app/apidoc/ifacemodule/browser.py
@@ -287,7 +287,11 @@ class InterfaceBreadCrumbs(object):
         mod_names = iface.__module__.split('.')
         obj = codeModule
         for name in mod_names:
-            obj = traverse(obj, name)
+            try:
+                obj = traverse(obj, name)
+            except KeyError: # pragma: no cover
+                # An unknown (root) module, such as logging
+                continue
             crumbs.append({
                 'name': name,
                 'url': absoluteURL(obj, self.request)

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,19 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,pypy
+envlist = py27,py34,py35,py36,py37,pypy,coverage
 
 [testenv]
 commands =
     zope-testrunner --test-path=src []
 deps =
     .[test]
+
+[testenv:coverage]
+usedevelop = true
+basepython =
+    python3.6
+commands =
+    coverage run -m zope.testrunner --test-path=src []
+    coverage report --fail-under=99
+deps =
+    {[testenv]deps}
+    coverage


### PR DESCRIPTION
The root code module now refuses to find any unregistered modules.

Actual modules can still look things up dynamically (e.g., zope.app.menus, which is created in ZCML).

Add a tox environment for coverage to be sure I didn't miss anything new.

Fixes #20.