### PR TITLE
Avoid AttributeError splitting qualnames in getPythonPath.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,7 +39,12 @@
   See `PR #15 <https://github.com/zopefoundation/zope.app.apidoc/pull/15/>`_.
 
 - ``__main__.py`` files are no longer imported by the code documentation module.
-  See `issue #22 <https://github.com/zopefoundation/zope.app.apidoc/issues/22>`_.
+  See `issue #22
+  <https://github.com/zopefoundation/zope.app.apidoc/issues/22>`_.
+
+- Cython functions registered as adapters on Python 2 no longer break
+  page generation with an ``AttributeError``. See `issue 25
+  <https://github.com/zopefoundation/zope.app.apidoc/issues/25>`_.
 
 4.0.0 (2017-05-25)
 ==================

--- a/src/zope/app/apidoc/utilities.py
+++ b/src/zope/app/apidoc/utilities.py
@@ -130,10 +130,12 @@ def getPythonPath(obj):
     # proxies for this check.
     naked = removeSecurityProxy(obj)
     qname = ''
-    if hasattr(naked, '__qualname__'):
-        # Python 3. This makes unbound functions inside classes
-        # do the same thing as they do an Python 2: return just their
-        # class name.
+    if isinstance(getattr(naked, '__qualname__', None), str):
+        # Python 3 (being sure to protect against non-str __qualname__
+        # that we could get on some versions of Cython. See
+        # https://github.com/zopefoundation/zope.app.apidoc/issues/25).
+        # This makes unbound functions inside classes do the same
+        # thing as they do an Python 2: return just their class name.
         qname = naked.__qualname__
         qname = qname.split('.')[0]
     if hasattr(naked, 'im_class'):


### PR DESCRIPTION
Fixes #25.